### PR TITLE
Hide rows with no PII entity detections in main classification table

### DIFF
--- a/clients/spark_client.py
+++ b/clients/spark_client.py
@@ -94,9 +94,11 @@ class SparkClient:
         df = self._spark.table(table_name)
 
         # Filter data where schema_name and table_name equals the source_table_name
+        # and PII entity is not null. The rows with no detected PII entity will be displayed in a separate table.
         df_filtered = df.filter(
             (functions.col(const.RESULT_TABLE_SCHEMA_NAME_KEY) == schema)
             & (functions.col(const.RESULT_TABLE_TABLE_NAME_KEY) == table)
+            & (functions.col(const.SUMMARY_PII_ENTITY_KEY).isNotNull())
         )
 
         # We should have one row per (schema, table, column name, pii entity)


### PR DESCRIPTION
We currently shows rows with no detected PII entities along with other detected rows. These rows are currently unselectable because we do not yet have any action that the user can take on them. In the future we want to support manually adding tags for these rows, but until then we want to hide these rows from the main table to make the UX clearer. 

Before:
<img width="1693" alt="image" src="https://github.com/user-attachments/assets/1a8f20f3-b961-4912-88ad-f92f49664851">

After:
<img width="1713" alt="image" src="https://github.com/user-attachments/assets/dcf71476-44a6-4377-a1cf-7c7495cb52af">
