### PR TITLE
[ML-48754] Pin databricks connect version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-connect==15.1
+databricks-connect==15.4
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-databricks-connect
+databricks-connect==15.1
 pandas


### PR DESCRIPTION
The Databricks connect client should not exceed the server’s version. This PR specifies the recommended client version that is compatible with serverless.